### PR TITLE
feat(auth): implement user registration endpoint

### DIFF
--- a/diabetapp-backend/package-lock.json
+++ b/diabetapp-backend/package-lock.json
@@ -10,9 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.12.0",
-        "express": "^5.1.0"
+        "bcrypt": "^6.0.0",
+        "express": "^5.1.0",
+        "zod": "^4.0.11"
       },
       "devDependencies": {
+        "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.3",
         "@types/node": "^24.1.0",
         "nodemon": "^3.1.10",
@@ -171,6 +174,16 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -345,6 +358,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1046,6 +1073,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
@@ -1609,6 +1656,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.11.tgz",
+      "integrity": "sha512-LVrgstTaQJek72n6ZGxhAhH/Q24PhGx4lIAcgBmjtvjRq0qYjiH9U0o3hfuC2vfExsnpoHElc4XOJjMKQjUQxg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/diabetapp-backend/package.json
+++ b/diabetapp-backend/package.json
@@ -15,9 +15,12 @@
   "type": "commonjs",
   "dependencies": {
     "@prisma/client": "^6.12.0",
-    "express": "^5.1.0"
+    "bcrypt": "^6.0.0",
+    "express": "^5.1.0",
+    "zod": "^4.0.11"
   },
   "devDependencies": {
+    "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.3",
     "@types/node": "^24.1.0",
     "nodemon": "^3.1.10",

--- a/diabetapp-backend/src/modules/auth/auth.controller.ts
+++ b/diabetapp-backend/src/modules/auth/auth.controller.ts
@@ -1,0 +1,95 @@
+import { Request, Response } from 'express';
+import { AuthService } from './auth.service';
+import { registerSchema } from './auth.validation';
+
+
+const authService = new AuthService();
+
+export const registerController = async (req: Request, res: Response) => {
+  try {
+    // 1. Validación con Zod
+    const validationResult = registerSchema.safeParse(req.body);
+    
+    if (!validationResult.success) {
+      return res.status(400).json({
+        success: false,
+        message: 'Datos de entrada inválidos',
+        errors: validationResult.error.issues.map(err => ({
+          field: err.path.join('.'),
+          message: err.message
+        }))
+      });
+    }
+
+    const userData = validationResult.data;
+
+    // 2. Crear usuario
+    const newUser = await authService.createUser(userData);
+
+    // 3. Respuesta exitosa
+    return res.status(201).json({
+      success: true,
+      message: 'Usuario registrado exitosamente',
+      data: {
+        user: newUser,
+        requiresOnboarding: true // Indicar que necesita completar perfil
+      }
+    });
+
+  } catch (error: any) {
+    // 4. Manejo específico de errores
+    switch (error.message) {
+      case 'USER_ALREADY_EXISTS':
+        return res.status(409).json({
+          success: false,
+          message: 'El correo electrónico ya está registrado',
+          code: 'EMAIL_IN_USE'
+        });
+      
+      case 'DATABASE_ERROR':
+        return res.status(500).json({
+          success: false,
+          message: 'Error en la base de datos. Intenta nuevamente.',
+          code: 'DB_ERROR'
+        });
+      
+      default:
+        console.error('Unexpected error in registerController:', error);
+        return res.status(500).json({
+          success: false,
+          message: 'Error interno del servidor',
+          code: 'INTERNAL_ERROR'
+        });
+    }
+  }
+};
+
+// Endpoint adicional para verificar disponibilidad de email
+export const checkEmailController = async (req: Request, res: Response) => {
+  try {
+    const { email } = req.query;
+    
+    if (!email || typeof email !== 'string') {
+      return res.status(400).json({
+        success: false,
+        message: 'Email es requerido'
+      });
+    }
+
+    const isAvailable = await authService.checkEmailAvailability(email);
+    
+    return res.status(200).json({
+      success: true,
+      data: {
+        email,
+        available: isAvailable
+      }
+    });
+    
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: 'Error verificando disponibilidad'
+    });
+  }
+};

--- a/diabetapp-backend/src/modules/auth/auth.routes.ts
+++ b/diabetapp-backend/src/modules/auth/auth.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { registerController, checkEmailController } from './auth.controller';
+
+const router = Router();
+
+// Definimos la ruta de registro
+router.post('/register', registerController);
+
+// Verificar disponibilidad de email (opcional, para UX)
+router.get('/check-email', checkEmailController);
+
+export default router;

--- a/diabetapp-backend/src/modules/auth/auth.service.ts
+++ b/diabetapp-backend/src/modules/auth/auth.service.ts
@@ -1,0 +1,76 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcrypt';
+import prisma from '../../config/db'; 
+import { RegisterUserInput } from './auth.types';
+
+
+export class AuthService {
+    async createUser(userData: RegisterUserInput) {
+      try {
+        // 1. Verificar si el usuario ya existe
+        const existingUser = await prisma.user.findUnique({
+          where: { email: userData.email.toLowerCase() }, // Normalizar email
+        });
+  
+        if (existingUser) {
+          throw new Error('USER_ALREADY_EXISTS');
+        }
+  
+        // 2. Hashear la contraseña (12 rounds para datos médicos)
+        const hashedPassword = await bcrypt.hash(userData.password, 12);
+  
+        // 3. Preparar datos para creación
+        const createData: any = {
+          email: userData.email.toLowerCase(),
+          password: hashedPassword,
+          firstName: userData.firstName,
+          lastName: userData.lastName,
+          typeOfDiabetes: userData.typeOfDiabetes,
+          onboardingCompleted: false, // Usuario nuevo necesita onboarding
+          isActive: true,
+          dataConsentAt: new Date(), // Registro implica consentimiento inicial
+        };
+  
+        // Procesar fecha de nacimiento si viene
+        if (userData.birthDate) {
+          createData.birthDate = new Date(userData.birthDate);
+        }
+  
+        // 4. Crear el nuevo usuario
+        const newUser = await prisma.user.create({
+          data: createData,
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            typeOfDiabetes: true,
+            onboardingCompleted: true,
+            createdAt: true,
+            // Excluir password explícitamente
+          }
+        });
+  
+        return newUser;
+  
+      } catch (error: any) {
+        // Re-lanzar errores conocidos
+        if (error.message === 'USER_ALREADY_EXISTS') {
+          throw error;
+        }
+        
+        // Error inesperado de Prisma o base de datos
+        console.error('Error creating user:', error);
+        throw new Error('DATABASE_ERROR');
+      }
+    }
+  
+    async checkEmailAvailability(email: string) {
+      const existingUser = await prisma.user.findUnique({
+        where: { email: email.toLowerCase() },
+        select: { id: true }
+      });
+      
+      return !existingUser; // true si está disponible
+    }
+  }

--- a/diabetapp-backend/src/modules/auth/auth.types.ts
+++ b/diabetapp-backend/src/modules/auth/auth.types.ts
@@ -1,0 +1,10 @@
+// types/auth.types.ts
+export interface RegisterUserInput {
+    email: string;
+    password: string;
+    firstName?: string;
+    lastName?: string;
+    typeOfDiabetes?: 'TYPE_1' | 'TYPE_2' | 'GESTACIONAL' | 'PREDIABETES';
+    birthDate?: string; // ISO date string
+  }
+  

--- a/diabetapp-backend/src/modules/auth/auth.validation.ts
+++ b/diabetapp-backend/src/modules/auth/auth.validation.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+export const registerSchema = z.object({
+    email: z
+      .string()
+      .email('Email debe tener formato válido')
+      .min(1, 'Email es obligatorio'),
+    
+    password: z
+      .string()
+      .min(8, 'Contraseña debe tener mínimo 8 caracteres')
+      .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/, 
+        'Contraseña debe tener al menos: 1 minúscula, 1 mayúscula, 1 número'),
+    
+    firstName: z
+      .string()
+      .min(2, 'Nombre debe tener mínimo 2 caracteres')
+      .optional(),
+    
+    lastName: z
+      .string()
+      .min(2, 'Apellido debe tener mínimo 2 caracteres')
+      .optional(),
+    
+    typeOfDiabetes: z
+      .enum(['TYPE_1', 'TYPE_2', 'GESTACIONAL', 'PREDIABETES'])
+      .optional(),
+    
+    birthDate: z
+      .string()
+      .datetime('Fecha debe ser formato ISO válido')
+      .optional()
+  });

--- a/diabetapp-backend/src/server.ts
+++ b/diabetapp-backend/src/server.ts
@@ -1,8 +1,10 @@
 // Importamos la librería Express
 import express, { Request, Response } from 'express';
+import authRoutes from './modules/auth/auth.routes';
 
 // Creamos una instancia de la aplicación Express
 const app = express();
+
 
 // Definimos el puerto en el que escuchará nuestro servidor
 // Usará el puerto que nos dé el hosting (process.env.PORT) o el 3000 si estamos en local
@@ -21,6 +23,8 @@ app.get('/api', (req: Request, res: Response) => {
   res.status(200).json({ message: '¡Hola, DiabetApp! El backend está funcionando.' });
 });
 
+// 2. Le decimos a la app que use nuestras nuevas rutas bajo el prefijo /api/auth
+app.use('/api/auth', authRoutes);
 // Ponemos el servidor a escuchar en el puerto definido
 app.listen(PORT, () => {
   console.log(`🚀 Servidor corriendo en http://localhost:${PORT}`);


### PR DESCRIPTION
Cierra el Issue #5.

Se ha implementado el endpoint de registro de usuarios en `POST /api/auth/register`.

**Funcionalidades:**
- Validación de email duplicado.
- Hashing de contraseñas con bcrypt.
- Creación del usuario en la base de datos.

**Pruebas:**
Se validaron los casos de uso para registro exitoso y de error (email duplicado, datos inválidos) con Postman. El endpoint funciona según lo esperado.

Listo para fusionar.