### PR TITLE
feat(db): define glucose_reading model and relation to user

### DIFF
--- a/diabetapp-backend/prisma/migrations/20250807231600_add_glucose_reading_model_and_relation/migration.sql
+++ b/diabetapp-backend/prisma/migrations/20250807231600_add_glucose_reading_model_and_relation/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "public"."glucose_readings" (
+    "id" TEXT NOT NULL,
+    "value" INTEGER NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL,
+    "momentOfDay" TEXT NOT NULL,
+    "notes" TEXT,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "glucose_readings_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."glucose_readings" ADD CONSTRAINT "glucose_readings_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/diabetapp-backend/prisma/schema.prisma
+++ b/diabetapp-backend/prisma/schema.prisma
@@ -66,10 +66,30 @@ model User {
   updatedAt       DateTime  @updatedAt
   
   // Relaciones futuras (preparación para Fase 2-3)
-  // glucoseReadings GlucoseReading[]
+   glucoseReadings GlucoseReading[]
   // medications     Medication[]
   // achievements    Achievement[]
   // dailyGoals      DailyGoal[]
+
   
-  @@map("users") // Nombre de tabla en plural
+  @@map("users") 
+}
+
+model GlucoseReading {
+  id        String    @id @default(cuid())
+  value     Int       // El valor en mg/dL, ej: 110
+
+  // Contexto del registro (según RF002)
+  timestamp DateTime  // Fecha y hora exactas del registro, enviadas desde el móvil
+  momentOfDay String    // "AYUNAS", "ANTES_COMIDA", "DESPUES_COMIDA", "NOCTURNA"
+  notes     String?   // Notas opcionales del usuario, ej: "Comí pizza"
+
+  // Relación con el usuario (¡LA PARTE MÁS IMPORTANTE!)
+  userId    String    // Clave foránea que apunta al ID del usuario
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // Metadata
+  createdAt DateTime  @default(now())
+
+  @@map("glucose_readings") // Nombre explícito para la tabla
 }


### PR DESCRIPTION
Un nuevo modelo GlucoseReading en schema.prisma con todos los campos necesarios.
Campos para el valor de la glucosa, el momento del día, notas, y otros datos contextuales.
Una relación de "uno a muchos" (one-to-many) definida entre User y GlucoseReading (Un usuario puede tener muchos registros de glucosa).
Una nueva migración de base de datos que creará la tabla glucose_readings en PostgreSQL y establecerá la clave foránea para conectarla con la tabla users.

*Closes #9 *